### PR TITLE
Add tocs to docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
 			"name": "MultiQC Website",
 			"version": "0.0.1",
 			"dependencies": {
-				"@astrojs/mdx": "^0.16.0",
+				"@astrojs/mdx": "^0.17.2",
 				"@astrojs/prefetch": "^0.1.2",
-				"@astrojs/sitemap": "^1.0.1",
-				"@astrojs/svelte": "^2.0.1",
+				"@astrojs/sitemap": "^1.1.0",
+				"@astrojs/svelte": "^2.0.2",
 				"@astrojs/tailwind": "^3.0.1",
 				"@tailwindcss/typography": "^0.5.9",
-				"astro": "^2.0.11",
+				"astro": "^2.0.16",
 				"astro-analytics": "^2.6.0",
 				"astro-icon": "^0.8.0",
 				"classnames": "^2.3.2",
-				"sass": "^1.58.1",
+				"sass": "^1.58.3",
 				"svelte": "^3.55.1",
 				"svelte-highlight": "^7.1.2",
-				"tailwindcss": "^3.2.6"
+				"tailwindcss": "^3.2.7"
 			},
 			"devDependencies": {
 				"@iconify/svelte": "^3.1.0",
@@ -120,16 +120,16 @@
 			"integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
 		},
 		"node_modules/@astrojs/mdx": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.16.0.tgz",
-			"integrity": "sha512-HNk0FhNNthI7+pLmheJyPVU36dXE5l+9UwmmnrMV6COHNZIO2t+pnWnsushEDYZjpkYITDwnXKnQAtD8Mqj4xw==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.17.2.tgz",
+			"integrity": "sha512-mol57cw1jJMcQgKMRGn7p6cewajq6JTNtqj5aAZgROWam/phVDSOCbXj/WU3O9+3qFnyKtpczoufQKwJTQltAw==",
 			"dependencies": {
 				"@astrojs/markdown-remark": "^2.0.1",
 				"@astrojs/prism": "^2.0.0",
-				"@mdx-js/mdx": "^2.1.2",
-				"@mdx-js/rollup": "^2.1.1",
+				"@mdx-js/mdx": "^2.3.0",
+				"@mdx-js/rollup": "^2.3.0",
 				"acorn": "^8.8.0",
-				"es-module-lexer": "^0.10.5",
+				"es-module-lexer": "^1.1.1",
 				"estree-util-visit": "^1.2.0",
 				"github-slugger": "^1.4.0",
 				"gray-matter": "^4.0.3",
@@ -145,11 +145,6 @@
 			"engines": {
 				"node": ">=16.12.0"
 			}
-		},
-		"node_modules/@astrojs/mdx/node_modules/es-module-lexer": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.5.tgz",
-			"integrity": "sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw=="
 		},
 		"node_modules/@astrojs/mdx/node_modules/github-slugger": {
 			"version": "1.5.0",
@@ -176,18 +171,18 @@
 			}
 		},
 		"node_modules/@astrojs/sitemap": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.0.1.tgz",
-			"integrity": "sha512-qexepZPH6/dLToI/njxr2FjvyxJU0HBAnQRNzEggF0ok811oSNC6su1DkyW2VKp0TNPbWoujuSbcb1yFOjnAqA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.1.0.tgz",
+			"integrity": "sha512-JnKZcbD0WdFxw2VAj3qXb0cYKuvk6nwBYPfUy+plSa9TC9hikQrDFpd7yapOPTRf3AdmUittzFckoTw/nUilCw==",
 			"dependencies": {
 				"sitemap": "^7.1.1",
 				"zod": "^3.17.3"
 			}
 		},
 		"node_modules/@astrojs/svelte": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@astrojs/svelte/-/svelte-2.0.1.tgz",
-			"integrity": "sha512-CEr6tVtyEq10oIiEZ4l4/RxpN6lMjJ3I5B92rhPy5BANiszlFWMajtBmvz6sEdU5TzELGgLJfZtqm3Gl6tpMSQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/svelte/-/svelte-2.0.2.tgz",
+			"integrity": "sha512-EkJT7Roft6v9CkI3/Hga8XQbmmI6kKcpOAx6E0gfepuJuqI68xLqnEl3TSJ9uH3dwJt8ThscB1TGxsc8B4JUdg==",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.2",
 				"svelte2tsx": "^0.5.11"
@@ -196,7 +191,7 @@
 				"node": ">=16.12.0"
 			},
 			"peerDependencies": {
-				"astro": "^2.0.4",
+				"astro": "^2.0.12",
 				"svelte": "^3.54.0"
 			}
 		},
@@ -216,9 +211,9 @@
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-2.0.0.tgz",
-			"integrity": "sha512-RnWojVMIsql3GGWDP5pNWmhmBQVkCpxGNZ8yPr2cbmUqsUYGSvErhqfkLfro9j2/STi5UDmSpNgjPkQmXpgnKw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-2.0.1.tgz",
+			"integrity": "sha512-68BLBb9CcvQMkWHE6h6VTgm5g6agm3+xm8eb3cdkmX9nP1LSQ/fiD49Jb1qAgCtWcY8yQJiWQQXwcdyStD+VoA==",
 			"dependencies": {
 				"ci-info": "^3.3.1",
 				"debug": "^4.3.4",
@@ -226,7 +221,7 @@
 				"dset": "^3.1.2",
 				"is-docker": "^3.0.0",
 				"is-wsl": "^2.2.0",
-				"undici": "^5.14.0",
+				"undici": "^5.20.0",
 				"which-pm-runs": "^1.1.0"
 			},
 			"engines": {
@@ -234,11 +229,11 @@
 			}
 		},
 		"node_modules/@astrojs/webapi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/webapi/-/webapi-2.0.0.tgz",
-			"integrity": "sha512-gziwy+XvY+/B9mq/eurgJMZ4iFnkcqg1wb0tA8BsVfiUPwl7yQKAFrBxrs2rWfKMXyWlVaTFc8rAYcB5VXQEuw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/webapi/-/webapi-2.0.2.tgz",
+			"integrity": "sha512-uSNtxLuvCWOcwy/DdIy30ocIcIUedEZpyhn1MHW3XuZ3PZHg4PMej3EP38Ns6uKgDKqMyEdscca9bMLuf4cO/w==",
 			"dependencies": {
-				"undici": "^5.14.0"
+				"undici": "5.20.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1538,15 +1533,15 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-2.0.11.tgz",
-			"integrity": "sha512-dXBuHE1ZYfafHyjhe7ZUkcZzGGInWrLCMeHAML//+mdySr/htDsiMo8DN25Ld5siKClsCvyXgxitu651wSWcyw==",
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-2.0.16.tgz",
+			"integrity": "sha512-noQL+bbBZaCLbh7wmpVON+e4kDxymDsIQkEUzzuMKLQodYynxr/Sp7RBA/JnEqXz4CRyd7IrgeQBN0cKOuBtzQ==",
 			"dependencies": {
 				"@astrojs/compiler": "^1.1.0",
 				"@astrojs/language-server": "^0.28.3",
 				"@astrojs/markdown-remark": "^2.0.1",
-				"@astrojs/telemetry": "^2.0.0",
-				"@astrojs/webapi": "^2.0.0",
+				"@astrojs/telemetry": "^2.0.1",
+				"@astrojs/webapi": "^2.0.2",
 				"@babel/core": "^7.18.2",
 				"@babel/generator": "^7.18.2",
 				"@babel/parser": "^7.18.4",
@@ -1590,7 +1585,7 @@
 				"typescript": "*",
 				"unist-util-visit": "^4.1.0",
 				"vfile": "^5.3.2",
-				"vite": "^4.0.3",
+				"vite": "^4.1.2",
 				"vitefu": "^0.2.4",
 				"yargs-parser": "^21.0.1",
 				"zod": "^3.17.3"
@@ -5669,9 +5664,9 @@
 			]
 		},
 		"node_modules/sass": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.1.tgz",
-			"integrity": "sha512-bnINi6nPXbP1XNRaranMFEBZWUfdW/AF16Ql5+ypRxfTvCRTTKrLsMIakyDcayUt2t/RZotmL4kgJwNH5xO+bg==",
+			"version": "1.58.3",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
+			"integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -6082,9 +6077,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.6.tgz",
-			"integrity": "sha512-BfgQWZrtqowOQMC2bwaSNe7xcIjdDEgixWGYOd6AL0CbKHJlvhfdbINeAW76l1sO+1ov/MJ93ODJ9yluRituIw==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
+			"integrity": "sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==",
 			"dependencies": {
 				"arg": "^5.0.2",
 				"chokidar": "^3.5.3",
@@ -6309,9 +6304,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.18.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-			"integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -6554,9 +6549,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
-			"integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+			"integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
 			"dependencies": {
 				"esbuild": "^0.16.14",
 				"postcss": "^8.4.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"astro-analytics": "^2.6.0",
 				"astro-icon": "^0.8.0",
 				"classnames": "^2.3.2",
+				"nanostores": "^0.7.4",
 				"sass": "^1.58.3",
 				"svelte": "^3.55.1",
 				"svelte-highlight": "^7.1.2",
@@ -4531,6 +4532,14 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/nanostores": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.7.4.tgz",
+			"integrity": "sha512-MBeUVt7NBcXqh7AGT+KSr3O0X/995CZsvcP2QEMP+PXFwb07qv3Vjyq+EX0yS8f12Vv3Tn2g/BvK/OZoMhJlOQ==",
+			"engines": {
+				"node": "^14.0.0 || ^16.0.0 || >=18.0.0"
 			}
 		},
 		"node_modules/nlcst-to-string": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"astro-analytics": "^2.6.0",
 		"astro-icon": "^0.8.0",
 		"classnames": "^2.3.2",
+		"nanostores": "^0.7.4",
 		"sass": "^1.58.3",
 		"svelte": "^3.55.1",
 		"svelte-highlight": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -12,20 +12,20 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"dependencies": {
-		"@astrojs/mdx": "^0.16.0",
+		"@astrojs/mdx": "^0.17.2",
 		"@astrojs/prefetch": "^0.1.2",
-		"@astrojs/sitemap": "^1.0.1",
-		"@astrojs/svelte": "^2.0.1",
+		"@astrojs/sitemap": "^1.1.0",
+		"@astrojs/svelte": "^2.0.2",
 		"@astrojs/tailwind": "^3.0.1",
 		"@tailwindcss/typography": "^0.5.9",
-		"astro": "^2.0.11",
+		"astro": "^2.0.16",
 		"astro-analytics": "^2.6.0",
 		"astro-icon": "^0.8.0",
 		"classnames": "^2.3.2",
-		"sass": "^1.58.1",
+		"sass": "^1.58.3",
 		"svelte": "^3.55.1",
 		"svelte-highlight": "^7.1.2",
-		"tailwindcss": "^3.2.6"
+		"tailwindcss": "^3.2.7"
 	},
 	"devDependencies": {
 		"@iconify/svelte": "^3.1.0",

--- a/src/components/MarkdownWrapper.svelte
+++ b/src/components/MarkdownWrapper.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { currentHeading } from '@components/store.js';
+
+    export let headings: { text: string; slug: string; depth: number;}[] = [];
+
+    // find current heading in viewport with IntersectionObserver
+    onMount(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        currentHeading.set(entry.target.id);
+                    }
+                });
+            },
+            {
+                rootMargin: '0px 0px -92% 0px', // 92% of viewport height to offset navbar
+            }
+        );
+        headings.forEach((heading) => {
+            const element = document.querySelector('#' + heading.slug);
+            observer.observe(element);
+        });
+    });
+</script>
+
+<div class="markdown-content">
+    <slot />
+</div>
+
+<style lang="scss">
+    .markdown-content :global(a) {
+        word-wrap: break-word; // long links break layout on small screens
+    }
+</style>

--- a/src/components/SidebarToc.svelte
+++ b/src/components/SidebarToc.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { currentHeading } from '@components/store.js';
+    import Icon from '@iconify/svelte';
+
+    export let headings: {
+        text: string;
+        slug: string;
+        depth: number;
+    }[];
+
+    const min_heading_depth = Math.min(...headings.map((h) => h.depth));
+    // make margin classes from min to max heading depth
+    // TODO: rewrite for tailwind
+    let headingMargin = {};
+    for (let i = min_heading_depth; i <= 4; i++) {
+        headingMargin[i] = 'pl-' + (i - min_heading_depth) * 2;
+    }
+</script>
+
+<div class="">
+    <div class="">
+        <strong class="">On this page</strong>
+        <nav class="">
+            <ul class="">
+                {#each headings as heading (heading)}
+                    <li
+                        class={' ' + headingMargin[heading.depth]}
+                        class:active={heading.slug === $currentHeading}
+                    >
+                        <a class="" href={'#' + heading.slug}>
+                            {@html heading.text}
+                        </a>
+                    </li>
+                {/each}
+            </ul>
+            <div class="">
+                <a
+                    href="#/"
+                    class=""
+                    on:click={() => window.scrollTo(0, 0)}
+                >
+                    <Icon icon="mdi:arrow-collapse-up" /> Back to top
+                </a>
+
+                <slot />
+            </div>
+        </nav>
+    </div>
+</div>
+
+<style lang="scss">
+</style>

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -1,0 +1,2 @@
+import { atom } from "nanostores";
+export const currentHeading = atom("");

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,17 +1,25 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
 import Hero from "@layouts/Hero.astro";
-
+import MarkdownWrapper from "@components/MarkdownWrapper.svelte";
+import SidebarToc from "@components/SidebarToc.svelte";
 export interface Props {
   title?: string;
   subtitle?: string;
   image?: string;
   md_github_url?: string;
   subfooter?: string;
-  docs_pages: object[];
+  docs_pages: {
+    title: string;
+    slug: string;
+  }[];
+  headings?: {
+    depth: number;
+    text: string;
+    slug: string;
+  }[];
 }
-
-const { title, subtitle, image, md_github_url, subfooter, docs_pages } = Astro.props;
+const { title, subtitle, image, md_github_url, subfooter, docs_pages, headings } = Astro.props;
 ---
 
 <BaseLayout
@@ -43,12 +51,15 @@ const { title, subtitle, image, md_github_url, subfooter, docs_pages } = Astro.p
 
       <!-- TODO: HACK! w-11/12 because otherwise the code blocks make it go super wide -->
       <main class="w-11/12 lg:w-[calc(100%-19.5rem)] xl:w-[calc(100%-39rem)]">
+        <MarkdownWrapper headings={headings} client:load>
+          <slot />
+        </MarkdownWrapper>
         <slot />
       </main>
       <nav
         class="sticky top-28 ml-5 hidden h-screen w-[19.5rem] flex-none overflow-y-auto pb-10 xl:block"
       >
-        // Fixed Table of contents
+        <SidebarToc headings={headings} client:visible />
       </nav>
     </div>
   </div>

--- a/src/pages/docs/[slug].astro
+++ b/src/pages/docs/[slug].astro
@@ -19,12 +19,14 @@ export async function getStaticPaths() {
 }
 
 const { Content, frontmatter } = Astro.props.post;
+const headings = Astro.props.post.getHeadings();
 ---
 
 <DocsLayout
   title={frontmatter.title}
   subtitle={frontmatter.description}
   docs_pages={Astro.props.docs_pages}
+  headings={headings}
 >
   <div class="prose max-w-none dark:prose-invert">
     <Content />


### PR DESCRIPTION
The styling is up to you.
Adds `.active` class to ToC element of heading currently in view (which can be fine-tuned with the `rootMargin` setting in `MarkdownWrapper.svelte`). 