### PR TITLE
Add tools page

### DIFF
--- a/src/pages/logos.astro
+++ b/src/pages/logos.astro
@@ -85,19 +85,19 @@ import { Icon } from "astro-icon";
         <h3 class="typo-h4 mb-4">MultiQC Logo</h3>
         <ul class="typo-body text-blue-400">
           <li>
-            <a href="../logos/multiqc_logo.png" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo.png" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               PNG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo.svg" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo.svg" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               SVG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo.ai" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo.ai" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               Illustrator</a
             >
@@ -115,19 +115,19 @@ import { Icon } from "astro-icon";
         <h3 class="typo-h4 mb-4 mr-10">MultiQC Logo (dark background)</h3>
         <ul class="typo-body text-blue-400">
           <li>
-            <a href="../logos/multiqc_logo_darkbg.png" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_darkbg.png" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               PNG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_darkbg.svg" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_darkbg.svg" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               SVG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_darkbg.ai" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_darkbg.ai" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               Illustrator</a
             >
@@ -147,19 +147,19 @@ import { Icon } from "astro-icon";
         <h3 class="typo-h4 mb-4 mr-10">MultiQC Square Thumb</h3>
         <ul class="typo-body text-blue-400">
           <li>
-            <a href="../logos/multiqc_logo_square.png" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_square.png" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               PNG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_square.svg" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_square.svg" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               SVG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_square.ai" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_square.ai" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               Illustrator</a
             >
@@ -177,19 +177,19 @@ import { Icon } from "astro-icon";
         <h3 class="typo-h4 mb-4 mr-10">MultiQC Circle Thumb</h3>
         <ul class="typo-body text-blue-400">
           <li>
-            <a href="../logos/multiqc_logo_circle.png" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_circle.png" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               PNG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_circle.svg" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_circle.svg" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               SVG</a
             >
           </li>
           <li class="mt-4">
-            <a href="../logos/multiqc_logo_circle.ai" class="hover:text-blue-600">
+            <a href="../logos/multiqc_logo_circle.ai" class="hover:text-blue-200">
               <Icon class="-mt-1 mr-2.5 h-6 w-6 inline" name="mdi:arrow-down-bold-circle-outline" />
               Illustrator</a
             >

--- a/src/pages/modules/[module].astro
+++ b/src/pages/modules/[module].astro
@@ -1,0 +1,24 @@
+---
+import PageLayout from "@layouts/PageLayout.astro";
+
+export async function getStaticPaths() {
+  const modules = await Astro.glob("../../../../MultiQC/docs/modules/**/*.md");
+  return modules.map((module) => ({
+    params: {
+      module: module.file.split("/").pop().replace(".md", ""),
+    },
+    props: {
+      module: module,
+      frontmatter: module.frontmatter,
+    },
+  }));
+}
+
+const { Content, frontmatter } = Astro.props.module;
+---
+
+<PageLayout title={"Module: " + frontmatter.Name} subtitle={frontmatter.Description}>
+  <div class="prose max-w-none dark:prose-invert">
+    <Content />
+  </div>
+</PageLayout>

--- a/src/pages/modules/index.astro
+++ b/src/pages/modules/index.astro
@@ -1,17 +1,17 @@
 ---
 import PageLayout from "@layouts/PageLayout.astro";
+import { Icon } from "astro-icon";
 
 const modules = await Astro.glob("../../../../MultiQC/docs/modules/**/*.md");
-console.log(modules);
 ---
 
 <PageLayout
   title={"Supported Tools"}
   subtitle={`MultiQC currently has modules to support ${modules.length} different bioinformatics tools, listed below.`}
 >
-  <div class="container-lg py-20">
+  <div class="container-lg">
     <div class="flex items-center">
-      <!-- <DocsIcon class="mr-3 h-6 w-6 text-gray-500" /> -->
+      <Icon name="mdi:book-outline" class="mr-3 h-10 w-10 text-gray-500" />
       <p class="typo-blockquote">
         Click the tool name to go to the MultiQC documentation for that tool.
       </p>
@@ -19,11 +19,11 @@ console.log(modules);
     <p class="mt-2">
       Missing something? If you would like another to be added, please{" "}
       <a
+        class="underline underline-offset-4"
         href="https://github.com/ewels/MultiQC/issues/new?labels=module%3A+new&template=module-request.yml"
       >
         open an issue
-      </a>
-      .
+      </a>.
     </p>
     <table class="mt-8">
       <thead>
@@ -42,12 +42,15 @@ console.log(modules);
             modules.map((module) => (
               <tr>
                 <td>
-                  <a href={module.path} class="typo-body text-blue-600">
-                    {module.title}
+                  <a
+                    href={"/modules/" + module.file.split("/").pop().replace(".md", "")}
+                    class="typo-body text-blue-600 dark:text-blue-400"
+                  >
+                    {module.frontmatter.Name}
                   </a>
                 </td>
                 <td>
-                  <p class="typo-body">{module.description}</p>
+                  <p class="typo-body">{module.frontmatter.Description}</p>
                 </td>
               </tr>
             ))

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,9 +16,16 @@
     border: 1px solid theme(colors.gray.200);
     @apply px-4 py-2 align-top;
   }
+  .dark table td {
+    border: 1px solid theme(colors.gray.700);
+  }
 
   table thead td {
     @apply bg-gray-100;
+  }
+
+  .dark table thead td {
+    @apply bg-zinc-700;
   }
 
   h1,


### PR DESCRIPTION
I added it according to the gatsby implementation.
Two things I would change:
- remove table borders (feels very 90s) 
- add a "Show details" button, which expands the markdown in the table (similar to the help text in the nf-co.re parameter page), it is usually only a short text and would fit nicely into the table without needing to go to an extra page