### PR TITLE
Add softlink in /public for markdown images

### DIFF
--- a/public/docs-images
+++ b/public/docs-images
@@ -1,0 +1,1 @@
+../../MultiQC/docs/docs-images


### PR DESCRIPTION
Softlink image dir in for markdown docs images.

Alternative to replacing with GitHub URLs on front end as done in https://github.com/ewels/MultiQC_website/pull/26

Works locally, curious to see if this works with the Netlify build.